### PR TITLE
Add screenshot capture quality dropdown menu

### DIFF
--- a/Source/CoffeeToolbar/Private/FToolbar.cpp
+++ b/Source/CoffeeToolbar/Private/FToolbar.cpp
@@ -105,24 +105,19 @@ void FToolbar::RegisterMenus()
 		));
 	}
 
-	if (Settings->bEnableScreenshotFeature)
-	{
-		Section.AddEntry(FToolMenuEntry::InitToolBarButton(
-			"CoffeeToolbar_Screenshot",
-			FUIAction(FExecuteAction::CreateRaw(ScreenshotFeature.Get(), &FScreenshotFeature::OnCaptureScreenshot)),
-			NSLOCTEXT("CoffeeToolbar", "Screenshot", "Screenshot"),
-			NSLOCTEXT("CoffeeToolbar", "Screenshot_Tip", "Take a screenshot of the active viewport (PIE or Editor)"),
-			FSlateIconFinder::FindIconForClass(ACameraActor::StaticClass()) // ← 카메라 아이콘
-		));
-
-		Section.AddEntry(FToolMenuEntry::InitToolBarButton(
-			"DoppleToolbar_OpenShotDir",
-			FUIAction(FExecuteAction::CreateRaw(ScreenshotFeature.Get(), &FScreenshotFeature::OnOpenScreenShotDir)),
-			NSLOCTEXT("CoffeeToolbar", "OpenShotDir", "Open Screenshot Folder"),
-			NSLOCTEXT("CoffeeToolbar", "OpenShotDir_Tip", "Open the project\'s screenshot directory"),
-			FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.FolderOpen")
-		));
-	}
+        if (Settings->bEnableScreenshotFeature)
+        {
+                FToolMenuEntry ScreenshotCombo = FToolMenuEntry::InitComboButton(
+                        "CoffeeToolbar_Screenshot",
+                        FUIAction(),
+                        FOnGetContent::CreateRaw(ScreenshotFeature.Get(), &FScreenshotFeature::GenerateScreenshotMenu),
+                        NSLOCTEXT("CoffeeToolbar", "Screenshot", "Screenshot"),
+                        NSLOCTEXT("CoffeeToolbar", "Screenshot_Tip", "Capture the active viewport with predefined resolutions."),
+                        FSlateIconFinder::FindIconForClass(ACameraActor::StaticClass())
+                );
+                ScreenshotCombo.StyleNameOverride = "CalloutToolbar";
+                Section.AddEntry(ScreenshotCombo);
+        }
 
 	if (Settings->bEnableCommandFeature)
 	{

--- a/Source/CoffeeToolbar/Private/Screenshot/FScreenshotFeature.cpp
+++ b/Source/CoffeeToolbar/Private/Screenshot/FScreenshotFeature.cpp
@@ -4,23 +4,105 @@
  */
 #include "Screenshot/FScreenshotFeature.h"
 #include "Common/FCommon.h" // For GetActiveTargetWorld
+#include "Framework/MultiBox/MultiBoxBuilder.h" // For FMenuBuilder
 #include "LevelEditor.h" // For FLevelEditorModule
 #include "IAssetViewport.h" // For IAssetViewport
 #include "Engine/Engine.h" // For GEngine
 #include "UnrealEdGlobals.h" // For GEditor
 #include "Misc/Paths.h" // For FPaths
 #include "HAL/FileManager.h" // For IFileManager
+#include "HAL/IConsoleManager.h" // For IConsoleVariable
 #include "HAL/PlatformProcess.h" // For FPlatformProcess
+#include "Styling/AppStyle.h" // For FAppStyle
+#include "Styling/SlateIcon.h" // For FSlateIcon
 
 /** @brief 스크린샷 기능의 기본 생성자입니다. */
 FScreenshotFeature::FScreenshotFeature()
 {
 }
 
-/** @brief 활성 뷰포트 또는 PIE 세션에서 스크린샷을 촬영합니다. */
-void FScreenshotFeature::OnCaptureScreenshot()
+/** @brief 스크린샷 옵션을 제공하는 메뉴 위젯을 구성합니다. */
+TSharedRef<SWidget> FScreenshotFeature::GenerateScreenshotMenu()
 {
-    // 1) PIE 중이면 게임뷰포트에 고해상도 캡쳐
+    FMenuBuilder MenuBuilder(true, nullptr);
+
+    MenuBuilder.AddMenuEntry(
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_QuickPreview", "개발 중 빠른 참고 (1x)"),
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_QuickPreview_Tooltip", "현재 활성 뷰포트를 1배 해상도로 빠르게 캡쳐합니다."),
+        FSlateIcon(),
+        FUIAction(FExecuteAction::CreateRaw(this, &FScreenshotFeature::OnCaptureQuickPreview))
+    );
+
+    MenuBuilder.AddMenuEntry(
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_Standard", "보통 (2x)"),
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_Standard_Tooltip", "현재 활성 뷰포트를 2배 배율로 캡쳐합니다."),
+        FSlateIcon(),
+        FUIAction(FExecuteAction::CreateRaw(this, &FScreenshotFeature::OnCaptureStandard))
+    );
+
+    MenuBuilder.AddMenuEntry(
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_High", "고해상도 (4x)"),
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_High_Tooltip", "현재 활성 뷰포트를 4배 배율로 캡쳐합니다."),
+        FSlateIcon(),
+        FUIAction(FExecuteAction::CreateRaw(this, &FScreenshotFeature::OnCaptureHighResolution))
+    );
+
+    MenuBuilder.AddMenuEntry(
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_Ultra", "울트라 (8x)"),
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_Ultra_Tooltip", "현재 활성 뷰포트를 8배 배율로 캡쳐합니다."),
+        FSlateIcon(),
+        FUIAction(FExecuteAction::CreateRaw(this, &FScreenshotFeature::OnCaptureUltra))
+    );
+
+    MenuBuilder.AddMenuSeparator();
+
+    MenuBuilder.AddMenuEntry(
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_OpenFolder", "캡쳐 폴더 열기"),
+        NSLOCTEXT("CoffeeToolbar", "Screenshot_OpenFolder_Tooltip", "스크린샷이 저장된 캡쳐 폴더를 엽니다."),
+        FSlateIcon(FAppStyle::GetAppStyleSetName(), "Icons.FolderOpen"),
+        FUIAction(FExecuteAction::CreateRaw(this, &FScreenshotFeature::OnOpenScreenShotDir))
+    );
+
+    return MenuBuilder.MakeWidget();
+}
+
+/** @brief 빠른 참고용 스크린샷을 촬영합니다. */
+void FScreenshotFeature::OnCaptureQuickPreview()
+{
+    CaptureActiveViewport(1);
+}
+
+/** @brief 표준 배율 스크린샷을 촬영합니다. */
+void FScreenshotFeature::OnCaptureStandard()
+{
+    CaptureActiveViewport(2);
+}
+
+/** @brief 고해상도 스크린샷을 촬영합니다. */
+void FScreenshotFeature::OnCaptureHighResolution()
+{
+    CaptureActiveViewport(4);
+}
+
+/** @brief 울트라 고해상도 스크린샷을 촬영합니다. */
+void FScreenshotFeature::OnCaptureUltra()
+{
+    CaptureActiveViewport(8);
+}
+
+/** @brief 지정된 배율로 활성 뷰포트에 고해상도 캡처를 요청합니다. */
+void FScreenshotFeature::CaptureActiveViewport(int32 ResolutionMultiplier)
+{
+    if (ResolutionMultiplier <= 0)
+    {
+        ResolutionMultiplier = 1;
+    }
+
+    if (IConsoleVariable* ResolutionCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.HighResScreenshot.ResolutionMultiplier")))
+    {
+        ResolutionCVar->Set(ResolutionMultiplier);
+    }
+
     if (GEngine && GEditor &&
         GEditor->PlayWorld &&
         GEngine->GameViewport &&
@@ -31,19 +113,21 @@ void FScreenshotFeature::OnCaptureScreenshot()
         return;
     }
 
-    // 2) 에디터 레벨 뷰포트가 있으면 그쪽에서 캡쳐
-    if (FLevelEditorModule* LEM = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor"))
+    if (FLevelEditorModule* LevelEditorModule = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor"))
     {
-        if (TSharedPtr<IAssetViewport> AV = LEM->GetFirstActiveViewport())
+        if (TSharedPtr<IAssetViewport> AssetViewport = LevelEditorModule->GetFirstActiveViewport())
         {
-            FEditorViewportClient& VC = AV->GetAssetViewportClient();
-            VC.TakeHighResScreenShot();
+            FEditorViewportClient& ViewportClient = AssetViewport->GetAssetViewportClient();
+            ViewportClient.TakeHighResScreenShot();
             return;
         }
     }
 
-    if (UWorld* W = FCommon::GetActiveTargetWorld())
-        GEditor->Exec(W, TEXT("HighResShot 1"));
+    if (UWorld* World = FCommon::GetActiveTargetWorld())
+    {
+        const FString Command = FString::Printf(TEXT("HighResShot %d"), ResolutionMultiplier);
+        GEditor->Exec(World, *Command);
+    }
 }
 
 /** @brief 촬영된 스크린샷이 저장된 디렉터리를 엽니다. */

--- a/Source/CoffeeToolbar/Public/Screenshot/FScreenshotFeature.h
+++ b/Source/CoffeeToolbar/Public/Screenshot/FScreenshotFeature.h
@@ -17,9 +17,25 @@ public:
     /** @brief 기본 스크린샷 설정 상태를 구성합니다. */
     FScreenshotFeature();
 
-    /** @brief 언리얼 자동화 라이브러리를 사용해 스크린샷을 촬영합니다. */
-    void OnCaptureScreenshot();
+    /** @brief 스크린샷 옵션을 제공하는 메뉴 위젯을 생성합니다. */
+    TSharedRef<SWidget> GenerateScreenshotMenu();
+
+    /** @brief 빠른 참고용 스크린샷(1x 배율)을 촬영합니다. */
+    void OnCaptureQuickPreview();
+
+    /** @brief 보통 품질 스크린샷(2x 배율)을 촬영합니다. */
+    void OnCaptureStandard();
+
+    /** @brief 고해상도 스크린샷(4x 배율)을 촬영합니다. */
+    void OnCaptureHighResolution();
+
+    /** @brief 울트라 고해상도 스크린샷(8x 배율)을 촬영합니다. */
+    void OnCaptureUltra();
 
     /** @brief 촬영된 스크린샷이 저장된 디렉터리를 엽니다. */
     void OnOpenScreenShotDir();
+
+private:
+    /** @brief 지정된 배율로 활성 뷰포트에 고해상도 캡처를 요청합니다. */
+    void CaptureActiveViewport(int32 ResolutionMultiplier);
 };


### PR DESCRIPTION
## Summary
- replace the screenshot toolbar button with a combo dropdown that exposes capture presets and the capture folder shortcut
- add screenshot helper methods to drive the new menu and honor different high resolution multipliers

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35b70313483298a4e90706d9b8a90