### PR TITLE
Translate README.en.md to English

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,119 +11,117 @@
 
 ![Coffee Toolbar Icon](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/icon_coffee_cover_type3.png)
 
-`Coffee Toolbar`는 언리얼 엔진 에디터의 개발 편의성을 향상시키기 위해 제작된 유틸리티 툴바 플러그인입니다. 자주 사용하는 기능들을 원클릭으로 실행하여 반복적인 작업을 줄이고 개발 속도를 높이는 것을 목표로 합니다.
+`Coffee Toolbar` is a utility toolbar plug-in designed to enhance productivity in the Unreal Engine editor. By launching frequently used actions with a single click, it minimizes repetitive work and speeds up development.
 
-![사용법](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/use_guide.png?raw=true)
+![How it works](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/use_guide.png?raw=true)
 
-## 주요 기능 (Features)
+## Key Features
 
-*   **커스텀 콘솔 명령어 실행**: 설정 파일에 미리 정의된 다수의 콘솔 명령어들을 버튼 하나로 실행할 수 있습니다.
-*   **레벨 관련 기능**: 현재 레벨의 모든 액터를 빌드하거나, 라이팅을 빌드하는 등 레벨 관리에 유용한 기능들을 제공합니다.
-*   **고해상도 스크린샷**: 지정된 배율(예: 2x, 4x)로 고해상도 스크린샷을 간편하게 촬영하고 저장 폴더를 바로 열 수 있습니다.
-*   **설정 기반 확장성**: `.ini` 파일을 통해 툴바에 표시될 기능과 순서를 사용자가 직접 커스터마이징할 수 있습니다.
+* **Run custom console commands** – Execute any number of pre-defined console commands from a configuration file with one button press.
+* **Level management tools** – Build every actor in the current level, build lighting, and access other helpers that streamline level management.
+* **High-resolution screenshots** – Capture screenshots at preset multipliers (for example, 2× or 4×) and open the output folder instantly.
+* **Configuration-driven extensibility** – Customize which features appear in the toolbar and their order through `.ini` files.
 
-## 설치 방법 (Installation)
+## Installation
 
-### 1. GitHub Release를 통한 설치 (권장)
+### 1. Install from GitHub Releases (Recommended)
 
-1.  [GitHub Releases 페이지](https://github.com/doppleddiggong/CoffeeToolbar/releases)에서 최신 버전의 `CoffeeToolbar_X.X.X.zip` 파일을 다운로드합니다.
-2.  다운로드한 ZIP 파일의 압축을 해제합니다.
-3.  압축 해제된 `CoffeeToolbar` 폴더를 언리얼 엔진 프로젝트의 `Plugins` 폴더 (예: `YourProject/Plugins/`) 또는 언리얼 엔진 설치 경로의 `Engine/Plugins` 폴더 (예: `C:/Program Files/Epic Games/UE_5.X/Engine/Plugins/`) 안에 복사합니다.
-4.  언리얼 엔진 에디터를 재시작합니다.
-5.  에디터 상단 메뉴에서 `Edit > Plugins`를 선택하고, "CoffeeToolbar"를 검색하여 활성화합니다.
-6.  플러그인 활성화 후 에디터 재시작 메시지가 나타나면 재시작합니다.
+1. Download the latest `CoffeeToolbar_X.X.X.zip` file from the [GitHub Releases page](https://github.com/doppleddiggong/CoffeeToolbar/releases).
+2. Extract the downloaded ZIP file.
+3. Copy the extracted `CoffeeToolbar` folder into your Unreal Engine project’s `Plugins` directory (for example, `YourProject/Plugins/`) or into the engine installation directory at `Engine/Plugins` (for example, `C:/Program Files/Epic Games/UE_5.X/Engine/Plugins/`).
+4. Restart the Unreal Engine editor.
+5. In the editor menu, choose `Edit > Plugins`, search for “CoffeeToolbar,” and enable it.
+6. Restart the editor if prompted after enabling the plug-in.
 
-### 2. 프로젝트에 수동 설치
+### 2. Manual installation in a project
 
-1.  프로젝트 폴더 내에 `Plugins` 폴더가 없다면 생성합니다.
-2.  `CoffeeToolbar` 폴더를 `Plugins` 폴더 안으로 복사합니다.
-3.  프로젝트를 재시작한 후, `Edit > Plugins` 메뉴에서 `CoffeeToolbar`를 찾아 활성화합니다.
+1. Create a `Plugins` folder in your project directory if it does not already exist.
+2. Copy the `CoffeeToolbar` folder into the `Plugins` directory.
+3. Restart the project, then go to `Edit > Plugins` and enable `CoffeeToolbar`.
 
-**경로 예시**: `[YourProjectDirectory]/Plugins/CoffeeToolbar`
+**Path example**: `[YourProjectDirectory]/Plugins/CoffeeToolbar`
 
-### 3. 엔진에 수동 설치
+### 3. Manual installation in the engine
 
-1.  언리얼 엔진 설치 경로의 `Engine/Plugins` 폴더로 이동합니다.
-2.  `CoffeeToolbar` 폴더를 `Engine/Plugins` 폴더 안으로 복사합니다.
-3.  엔진을 재시작한 후, `Edit > Plugins` 메뉴에서 `CoffeeToolbar`를 찾아 활성화합니다.
+1. Navigate to the `Engine/Plugins` directory inside your Unreal Engine installation path.
+2. Copy the `CoffeeToolbar` folder into the `Engine/Plugins` directory.
+3. Restart the engine, then go to `Edit > Plugins` and enable `CoffeeToolbar`.
 
-**경로 예시**: `C:/Program Files/Epic Games/UE_5.X/Engine/Plugins/CoffeeToolbar`
+**Path example**: `C:/Program Files/Epic Games/UE_5.X/Engine/Plugins/CoffeeToolbar`
 
-## 사용법 (How to Use)
+## How to Use
 
-1.  플러그인이 활성화되면 에디터 상단 메인 툴바에 새로운 **커피 아이콘**이 나타납니다.
-2.  툴바 아이콘을 클릭하면 등록된 기능 버튼들이 드롭다운 메뉴 형식으로 표시됩니다.
-3.  원하는 기능의 버튼을 클릭하여 즉시 실행합니다.
+1. After activation, a new **coffee icon** appears in the main toolbar at the top of the editor.
+2. Click the toolbar icon to open a drop-down menu that lists all registered feature buttons.
+3. Click any button to execute the corresponding action immediately.
 
-## 설정 가이드 (Configuration Guide)
+## Configuration Guide
 
-`Coffee Toolbar` 플러그인은 언리얼 엔진의 **Project Settings**를 통해 다양한 기능을 설정하고 커스터마이징할 수 있습니다.
+You can configure and customize every aspect of `Coffee Toolbar` through the Unreal Engine **Project Settings** menu.
 
-![설정 수정](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/modify_guide.png?raw=true)
+![Editing settings](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/modify_guide.png?raw=true)
 
-### 1. 플러그인 설정 접근
+### 1. Access the plug-in settings
 
-언리얼 에디터에서 **Edit > Project Settings**로 이동한 후, 왼쪽 메뉴의 **Plugins** 섹션에서 **Coffee Toolbar**를 선택합니다.
+In the Unreal Editor, go to **Edit > Project Settings** and select **Coffee Toolbar** under the **Plugins** section in the left-hand menu.
 
-### 2. 기본 설정 (Default Settings)
+### 2. Default settings
 
-여기서 툴바에 표시될 버튼의 순서, 아이콘, 실행할 명령어 등을 설정할 수 있습니다.
+Configure the order of toolbar buttons, their icons, and the commands they execute.
 
-![기본 설정](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_defaultSetting.png?raw=true)
+![Default settings](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_defaultSetting.png?raw=true)
 
-### 3. 커스텀 명령어 추가 (Adding Custom Commands)
+### 3. Adding custom commands
 
-**Custom Commands** 섹션에서 새로운 요소를 추가하여 원하는 콘솔 명령어 또는 에디터 기능을 툴바 버튼으로 등록할 수 있습니다.
+In the **Custom Commands** section, add new entries to register console commands or editor functions as toolbar buttons.
 
-![커맨드 설정](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_command.png?raw=true)
+![Command settings](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_command.png?raw=true)
 
-### 4. 레벨 셀렉터 설정 (Level Selector Configuration)
+### 4. Configuring the Level Selector
 
-**Level Selector** 기능을 통해 자주 사용하는 레벨들을 등록하고 툴바에서 빠르게 로드할 수 있습니다.
+Use the **Level Selector** to register frequently used levels and load them from the toolbar with a single click.
 
+**Button overview:**
 
-**주요 버튼 설명:**
+* **Add Current Level** – Adds the level currently loaded in the editor to the list.
+* **Load Selected Level** – Loads the level selected in the list into the editor.
+* **Remove Selected Level** – Deletes the selected level from the list.
+* **Clear All Levels** – Removes every registered level from the list.
 
-*   **Add Current Level**: 현재 에디터에 로드된 레벨을 목록에 추가합니다.
-*   **Load Selected Level**: 목록에서 선택된 레벨을 에디터에 로드합니다.
-*   **Remove Selected Level**: 목록에서 선택된 레벨을 제거합니다.
-*   **Clear All Levels**: 목록의 모든 레벨을 제거합니다.
+![Level selector settings](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_levelselector.png?raw=true)
 
-![레벨 셀렉터 설정](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_levelselector.png?raw=true)
+### 5. Screenshot capture feature
 
-### 5. 스크린샷 설정 (Screenshot Capture Feature)
+Use the **Screenshot** tools to capture high-resolution screenshots of the active viewport or open the capture folder instantly.
 
-**Screenshot** 기능을 통해 현재 활성 뷰포트의 고해상도 스크린샷을 촬영하거나, 캡처 폴더를 바로 열 수 있습니다.
+#### Available actions
+- **Capture at 1×** – Capture at the current resolution.
+- **Capture at 2×** – Capture at 2× resolution.
+- **Capture at 4×** – Capture at 4× resolution.
+- **Capture at 8×** – Capture at 8× resolution.
+- **Open capture folder** – Open the folder that contains your saved screenshots.
 
-#### 제공 기능
-- **1배 촬영** : 현재 해상도로 캡처
-- **2배 촬영** : 2배 배율로 캡처
-- **4배 촬영** : 4배 배율로 캡처
-- **8배 촬영** : 8배 배율로 캡처
-- **캡처 폴더 열기** : 저장된 스크린샷 폴더를 바로 탐색기에서 엽니다
-
-![스크린샷 설정](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_screenshot.png?raw=true)
+![Screenshot settings](https://github.com/doppleddiggong/CoffeeToolbar/blob/main/Documents/Reference/guide_screenshot.png?raw=true)
 
 ---
 
-## 설정 상세 (Configuration Details)
+## Configuration Details
 
-`Project Settings > Plugins > Coffee Toolbar` 메뉴를 통해 플러그인의 동작을 상세하게 설정할 수 있습니다.
+Use the `Project Settings > Plugins > Coffee Toolbar` menu to fine-tune how the plug-in behaves.
 
-*   **콘솔 명령어 등록**: 툴바를 통해 실행할 커스텀 콘솔 명령어 목록을 추가하거나 수정할 수 있습니다.
-*   **툴바 기능 활성화/비활성화**: 툴바에 표시할 개별 기능들을 선택적으로 켜고 끌 수 있습니다.
+* **Register console commands** – Add or edit the list of custom console commands available through the toolbar.
+* **Toggle toolbar features** – Choose which features appear in the toolbar.
 
-설정된 내용은 프로젝트의 `Config/ToolbarSettings.ini` 파일에 저장됩니다.
+All configuration data is stored in the project’s `Config/ToolbarSettings.ini` file.
 
+## License
 
-## 라이선스 (License)
-
-본 플러그인은 MIT 라이선스 하에 배포됩니다. 자세한 내용은 `LICENSE` 파일을 참고하십시오.
+This plug-in is distributed under the MIT License. See the `LICENSE` file for details.
 
 ## Author
 
 **dopple**
 
-- GitHub: [doppleddiggong](https://github.com/doppleddiggong)  
-- LinkedIn: [주백 배](https://www.linkedin.com/in/주백-배-4a814527b/)  
-- Email: dopple [at] yourdomain.com  
+- GitHub: [doppleddiggong](https://github.com/doppleddiggong)
+- LinkedIn: [Jubaek Bae](https://www.linkedin.com/in/주백-배-4a814527b/)
+- Email: dopple [at] yourdomain.com


### PR DESCRIPTION
## Summary
- replace the Korean text in README.en.md with a full English translation
- clarify feature descriptions, installation steps, and configuration guidance in English

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3913e19e08329a75718ddbdeffd9d